### PR TITLE
Links option in OpenInExplorer.lua

### DIFF
--- a/contrib/OpenInExplorer.lua
+++ b/contrib/OpenInExplorer.lua
@@ -32,11 +32,17 @@ Install: (see here for more detail: https://github.com/darktable-org/lua-scripts
 
 Select the photo(s) you wish to find in your operating system's file manager and press "show in file explorer" in the "selected images" section.
 
-- Nautilus (Linux), Explorer (Windows), and Finder (macOS before Catalina) will open one window for each selected image at the file's location. The file name will be highlighted.
+- Nautilus (Linux), Explorer (Windows), and Finder (macOS prior to Mojave) will open one window for each selected image at the file's location. The file name will be highlighted.
 
-- On macOS Catalina the Finder will open one window for each different directory. In these windows only the last one of the corresponding files will be highlighted (bug or feature?).
+- On macOS Mojave and Catalina the Finder will open one window for each different directory. In these windows only the last one of the corresponding files will be highlighted (bug or feature?).
 
 - Dolphin (Linux) will open one window with tabs for the different directories. All the selected images' file names are highlighted in their respective directories.
+
+As an alternative option you can choose to show the image file names as symbolic links in an arbitrary directory. Go to preferences|Lua options. This option is not available for Windows users as on Windows solely admins are allowed to create links.
+
+- Pros: You do not clutter up your display with multiple windows. So there is no need to limit the number of selections.
+
+- Cons: If you want to work with the files you are one step behind the original data.
 
 ----KNOWN ISSUES----
 ]]
@@ -50,6 +56,7 @@ local gettext = dt.gettext
 --Check API version
 du.check_min_api_version("5.0.0", "OpenInExplorer") 
 
+-- Tell gettext where to find the .mo file translating messages for a particular domain
 gettext.bindtextdomain("OpenInExplorer",dt.configuration.config_dir.."/lua/locale/")
 
 local function _(msgid)
@@ -59,53 +66,143 @@ end
 local act_os = dt.configuration.running_os
 local PS = act_os == "windows" and  "\\"  or  "/"
 
---Detect OS and quit if it is not supported--	
-local proper_install = true
+--Detect OS and quit if it is not supported.	
 if act_os ~= "macos" and act_os ~= "windows" and act_os ~= "linux" then
-  proper_install = false
-  dt.print_error(_('OpenInExplorer plug-in only supports Linux, macOS, and Windows at this time'))
+  dt.print(_("OpenInExplorer plug-in only supports Linux, macOS, and Windows at this time"))
+  dt.print_error("OpenInExplorer plug-in only supports Linux, macOS, and Windows at this time")
   return
 end
 
---Format strings for the commands to open the corresponding OS' file manager
-local fmng_cmd = {}
-fmng_cmd.linux = [[busctl --user call org.freedesktop.FileManager1 /org/freedesktop/FileManager1 org.freedesktop.FileManager1 ShowItems ass %d %s""]]
-fmng_cmd.macos = 'open -Rn %s'
-fmng_cmd.windows = 'explorer.exe /select, %s'
+local use_links, links_dir = false, ""
+if act_os ~= "windows" then
+  use_links = dt.preferences.read("OpenInExplorer", "use_links", "bool")
+  links_dir = dt.preferences.read("OpenInExplorer", "linked_image_files_dir", "string")
+end
 
---The working function that opens the file manager windows with the selected image file names highlighted.
-local function open_in_fmanager(op_sys, fmcmd)
-  local images = dt.gui.selection()
-  local curr_image, run_cmd, file_uris = '', '', ''
-  if #images == 0 then
-    dt.print(_('Please select an image'))
-  elseif #images <= 15 then
-    for _,image in pairs(images) do
-      curr_image = image.path..PS..image.filename
-      if op_sys == 'linux' then
-        file_uris = file_uris .. df.sanitize_filename("file://" .. curr_image) .. " "
-        dt.print_log("file_uris is " .. file_uris)
-      else
-        run_cmd = string.format(fmcmd, df.sanitize_filename(curr_image))
-        dt.print_log("OpenInExplorer run_cmd = "..run_cmd)
-        dsys.external_command(run_cmd)
-      end
-    end
-    if op_sys == 'linux' then
-      run_cmd = string.format(fmcmd, #images, file_uris)
-      dt.print_log("OpenInExplorer run_cmd = "..run_cmd)
-      dsys.external_command(run_cmd)
-    end
-  else
-    dt.print(_('Please select fewer images (max 15)'))
+--Check if the directory exists that was chosen for the file links. Return boolean.
+local function check_if_links_dir_exists()
+  local dir_exists = true
+  if not links_dir then
+    --Just for paranoic reasons. I tried, but I couldn't devise a setting for a nil value.
+    dt.print(_("No links directory selected.\nPlease check the dt preferences (lua options)"))
+    dt.print_error("OpenInExplorer: No links directory selected")
+    dir_exists = false
+  elseif not df.check_if_file_exists(links_dir) then
+    dt.print(string.format(_("Links directory '%s' not found.\nPlease check the dt preferences (lua options)"), links_dir))
+    dt.print_error(string.format("OpenInExplorer: Links directory '%s' not found", links_dir))
+    dir_exists = false
+  end
+  return dir_exists
+end
+
+--Format strings for the commands to open the corresponding OS's file manager.
+local open_dir = {}
+open_dir.windows = "explorer.exe /n, %s"
+open_dir.macos = "open %s"
+open_dir.linux = [[busctl --user call org.freedesktop.FileManager1 /org/freedesktop/FileManager1 org.freedesktop.FileManager1 ShowFolders ass 1 %s ""]]
+
+local open_files = {}
+open_files.windows = "explorer.exe /select, %s"
+open_files.macos = "open -Rn %s"
+open_files.linux = [[busctl --user call org.freedesktop.FileManager1 /org/freedesktop/FileManager1 org.freedesktop.FileManager1 ShowItems ass %d %s ""]]
+
+--Call the file mangager for each selected image on Linux.
+--There is one call to busctl containing a list of all the image file names.
+local function call_list_of_files(selected_images)
+  local current_image, file_uris, run_cmd = "", "", ""
+  for _, image in pairs(selected_images) do
+    current_image = image.path..PS..image.filename
+    file_uris = file_uris .. df.sanitize_filename("file://" .. current_image) .. " "
+    dt.print_log("file_uris is " .. file_uris)
+  end
+  run_cmd = string.format(open_files.linux, #selected_images, file_uris)
+  dt.print_log("OpenInExplorer run_cmd = "..run_cmd)
+  dsys.external_command(run_cmd)
+end
+
+--Call the file manager for each selected image on Windows and macOS.
+local function call_file_by_file(selected_images)
+  local current_image, run_cmd = "", ""
+  for _, image in pairs(selected_images) do
+    current_image = image.path..PS..image.filename
+    run_cmd = string.format(open_files[act_os], df.sanitize_filename(current_image))
+    dt.print_log("OpenInExplorer run_cmd = "..run_cmd)
+    dsys.external_command(run_cmd)
   end
 end
 
+--Create a link for each selected image, and finally call the file manager.
+local function set_links(selected_images)
+  local current_image, link_target, run_cmd, k = "", "", "", nil
+  for k, image in pairs(selected_images) do
+    current_image = image.path..PS..image.filename
+    link_target = df.create_unique_filename(links_dir .. PS .. image.filename)
+    run_cmd = string.format("ln -s %s %s", df.sanitize_filename(current_image), df.sanitize_filename(link_target))
+    --[[
+    In case Windows will allow normal users to create soft links:
+    if act_os == "windows" then
+      run_cmd = string.format("mklink %s %s", df.sanitize_filename(link_target), df.sanitize_filename(current_image))
+    end
+    ]]
+    if dsys.external_command(run_cmd) ~= 0 then
+      dt.print(_("Failed to create links. Missing rights?"))
+      dt.print_error("OpenInExplorer: Failed to create links")
+      return
+    end
+  end
+  --The URI format is necessary only for the Linux busctl command.
+  --But it is accepted by the Windows Explorer and macOS's Finder all the same.
+  run_cmd = string.format(open_dir[act_os], df.sanitize_filename("file://"..links_dir))
+  dt.print_log("OpenInExplorer run_cmd = "..run_cmd)
+  dsys.external_command(run_cmd)
+end
+
+--The working function that starts the particular task.
+local function open_in_fmanager()
+  local images = dt.gui.selection()
+  if #images == 0 then
+    dt.print(_("Please select an image"))
+  else
+    if use_links and not check_if_links_dir_exists() then
+      return
+    end
+    if #images > 15 and not use_links then
+      dt.print(_("Please select fewer images (max. 15)"))
+    elseif use_links then
+      set_links(images)
+    else
+      if act_os == "linux" then
+        call_list_of_files(images)
+      else
+        call_file_by_file(images)
+      end
+    end
+  end
+end
+
+
 -- GUI --
-if proper_install then
-  dt.gui.libs.image.register_action(
-    _("show in file explorer"),
-    function() open_in_fmanager(act_os, fmng_cmd[act_os]) end,
-    _("Opens the file manager at the selected image's location")
+dt.gui.libs.image.register_action(
+  _("show in file explorer"),
+  function() open_in_fmanager() end,
+  _("Open the file manager at the selected image's location")
+)
+if act_os ~= "windows" then
+  dt.preferences.register("OpenInExplorer", "linked_image_files_dir",  -- name
+    "directory", -- type
+    _("OpenInExplorer: linked files directory"), -- label
+    _("Directory to store the links to the file names. Requires restart to take effect"),  -- tooltip
+    "Links to image files",  -- default
+    dt.new_widget("file_chooser_button"){
+      title = _("Select directory"),
+      is_directory = true,
+    }
   )
+    dt.preferences.register("OpenInExplorer", "use_links",  -- name
+      "bool", -- type
+      _("OpenInExplorer: use links"), -- label
+      _("Use links instead of multiple windows. Requires restart to take effect"),  -- tooltip
+      false,  -- default
+      ""
+    )
 end

--- a/locale/de_DE/LC_MESSAGES/OpenInExplorer.po
+++ b/locale/de_DE/LC_MESSAGES/OpenInExplorer.po
@@ -1,39 +1,78 @@
-# OpenInExplorer Darktable Plug-In.
-# Copyright (C) 2020 Volker Lenhardt
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Volker Lenhardt <volker.lenhardt@unitybox.de>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenInExplorer\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-19 14:43+0200\n"
+"POT-Creation-Date: 2020-06-11 19:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Volker Lenhardt <volker.lenhardt@unitybox.de>\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: OpenInExplorer.lua:64
+#: OpenInExplorer.lua:71
 msgid ""
-"OpenInExplorer plug-in only supports Linux, macOS, and Windows at this time"
-msgstr "OpenInExplorer-Plug-in kann nur auf macOS, Linux oder Windows laufen"
+"OpenInExplorer plug-in only supports Linux and macOS, and Windows at this time"
+msgstr "OpenInExplorer-Plug-in unterstützt zur Zeit nur Linux, macOS oder Windows"
 
-#: OpenInExplorer.lua:79
+#: OpenInExplorer.lua:87
+msgid ""
+"No links directory selected.\n"
+"Please check the dt preferences (lua options)"
+msgstr "Kein Verknüpfungs-Verzeichnis ausgewählt.\nBitte die dt-Voreinstellungen überprüfen (Lua-Optionen)"
+
+#: OpenInExplorer.lua:91
+#, lua-format
+msgid ""
+"Links directory '%s' not found.\n"
+"Please check the dt preferences (lua options)"
+msgstr "Das Verknüpfungs-Verzeichnis '%s' konnte nicht gefunden werden.\nBitte die dt-Voreinstellungen überprüfen (Lua-Optionen)"
+
+#: OpenInExplorer.lua:148
+msgid "Failed to create links. Missing rights?"
+msgstr "Die Verknüpfungen konnten nicht erstellt werden. Fehlende Rechte?"
+
+#: OpenInExplorer.lua:164
 msgid "Please select an image"
 msgstr "Es wurde kein Bild ausgewählt"
 
-#: OpenInExplorer.lua:98
-msgid "Please select fewer images (max 15)"
+#: OpenInExplorer.lua:170
+msgid "Please select fewer images (max. 15)"
 msgstr "Bitte nicht mehr als 15 Bilder auswählen"
 
-#: OpenInExplorer.lua:105
+#: OpenInExplorer.lua:186
 msgid "show in file explorer"
 msgstr "im Dateimanager anzeigen"
 
-#: OpenInExplorer.lua:107
-msgid "Opens the file manager at the selected image's location"
+#: OpenInExplorer.lua:188
+msgid "Open the file manager at the selected image's location"
 msgstr "Öffnet den Dateimanager an der Position des ausgewählten Bildes"
+
+#: OpenInExplorer.lua:193
+msgid "OpenInExplorer: linked files directory"
+msgstr "OpenInExplorer: Verknüpfungs-Verzeichnis"
+
+#: OpenInExplorer.lua:194
+msgid ""
+"Directory to store the links to the file names. Requires restart to take "
+"effect"
+msgstr "Verzeichnis für die Verknüpfungen zu den Dateinamen. Erfordert dt-Neustart"
+
+#: OpenInExplorer.lua:197
+msgid "Select directory"
+msgstr "Verzeichnis auswählen"
+
+#: OpenInExplorer.lua:203
+msgid "OpenInExplorer: use links"
+msgstr "OpenInExplorer: Verknüpfungen nutzen"
+
+#: OpenInExplorer.lua:204
+msgid "Use links instead of multiple windows. Requires restart to take effect"
+msgstr "Verknüpfungen statt einzelner Fenster nutzen. Erfordert dt-Neustart"


### PR DESCRIPTION
I added an option to contrib/OpenInExplorer.lua to use soft links in an arbitrary directory instead of opening one extra window for each selected image file in the OS's default file manager.

This option originates from the bug in the newer versions of macOS that the file manager Finder does not open a new window for each selected file, but only for each new directory, so the file name selections can only be recognized for the last file in the respective directory.

As Windows allows creating soft links in the terminal only to administrators, this option is not available to Windows users of dt.

In addition a provide a German translation for locate/de_DE/LC_MESSAGES/.